### PR TITLE
PoW connection slots to handle DDoS slot exhaustion attacks

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -126,6 +126,7 @@ BITCOIN_CORE_H = \
   pow/cuckoo_cycle/cuckoo.h \
   pow/cuckoo_cycle/siphash.h \
   pow/pow.h \
+  pow/sha256/sha256.h \
   pow.h \
   protocol.h \
   random.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -121,6 +121,9 @@ BITCOIN_CORE_H = \
   policy/fees.h \
   policy/policy.h \
   policy/rbf.h \
+  pow/cuckoo_cycle/cuckoo_miner.h \
+  pow/cuckoo_cycle/cuckoo.h \
+  pow/cuckoo_cycle/siphash.h \
   pow/pow.h \
   pow.h \
   protocol.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -121,6 +121,7 @@ BITCOIN_CORE_H = \
   policy/fees.h \
   policy/policy.h \
   policy/rbf.h \
+  pow/cuckoo_cycle/cuckoo_cycle.h \
   pow/cuckoo_cycle/cuckoo_miner.h \
   pow/cuckoo_cycle/cuckoo.h \
   pow/cuckoo_cycle/siphash.h \
@@ -320,6 +321,7 @@ libbitcoin_common_a_SOURCES = \
   netaddress.cpp \
   netbase.cpp \
   policy/feerate.cpp \
+  pow/cuckoo_cycle/cuckoo_cycle.cpp \
   protocol.cpp \
   scheduler.cpp \
   script/sign.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -78,6 +78,7 @@ endif
 BITCOIN_CORE_H = \
   addrdb.h \
   addrman.h \
+  ados.h \
   base58.h \
   bloom.h \
   blockencodings.h \
@@ -188,6 +189,7 @@ libbitcoin_server_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_server_a_SOURCES = \
   addrdb.cpp \
   addrman.cpp \
+  ados.cpp \
   bloom.cpp \
   blockencodings.cpp \
   chain.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -121,6 +121,7 @@ BITCOIN_CORE_H = \
   policy/fees.h \
   policy/policy.h \
   policy/rbf.h \
+  pow/pow.h \
   pow.h \
   protocol.h \
   random.h \
@@ -199,6 +200,7 @@ libbitcoin_server_a_SOURCES = \
   policy/fees.cpp \
   policy/policy.cpp \
   policy/rbf.cpp \
+  pow/pow.cpp \
   pow.cpp \
   rest.cpp \
   rpc/blockchain.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -56,6 +56,7 @@ BITCOIN_TESTS =\
   test/pmt_tests.cpp \
   test/policyestimator_tests.cpp \
   test/pow_tests.cpp \
+  test/pow_chain_tests.cpp \
   test/pow_sha256_tests.cpp \
   test/pow_cuckoo_cycle_tests.cpp \
   test/prevector_tests.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -57,6 +57,7 @@ BITCOIN_TESTS =\
   test/policyestimator_tests.cpp \
   test/pow_tests.cpp \
   test/pow_sha256_tests.cpp \
+  test/pow_cuckoo_cycle_tests.cpp \
   test/prevector_tests.cpp \
   test/raii_event_tests.cpp \
   test/random_tests.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -56,6 +56,7 @@ BITCOIN_TESTS =\
   test/pmt_tests.cpp \
   test/policyestimator_tests.cpp \
   test/pow_tests.cpp \
+  test/pow_sha256_tests.cpp \
   test/prevector_tests.cpp \
   test/raii_event_tests.cpp \
   test/random_tests.cpp \

--- a/src/ados.cpp
+++ b/src/ados.cpp
@@ -1,0 +1,189 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "ados.h"
+#include "net.h"
+#include "netmessagemaker.h"
+#include "hash.h"
+#include "arith_uint256.h"
+#include "key.h"
+#include "pow/sha256/sha256.h"
+#include "pow/cuckoo_cycle/cuckoo_cycle.h"
+
+#include <vector>
+#include <map>
+
+namespace ados {
+
+connection_challenge::connection_challenge(CNode& peer, offer_ref o_in) : callback(o_in), addr(peer.addr) {}
+
+bool connection_challenge::solved_challenge(powa::solution_ref sol) {
+    o->sol = sol;
+    printf("reconnecting to peer %s\n", addr.ToString().c_str());
+    g_connman.get()->OpenNetworkConnection(addr, false, NULL, NULL, false, false, true, o);
+    return true;
+}
+
+struct task {
+    uint32_t investment; ///< ticks per attempt
+    offer_ref o;         ///< offer associated with task
+    task(uint32_t investment_in, offer_ref o_in) : investment(investment_in), o(o_in) {}
+
+    bool operator==(const task& other) const { return investment == other.investment && o.get() == other.o.get(); }
+};
+
+struct expiring_hash {
+    int64_t expiration;
+    uint256 hash;
+    bool operator<(const expiring_hash& other) const { return expiration < other.expiration || (expiration == other.expiration && hash < other.hash); }
+};
+
+CKey* ados_key = NULL;
+std::set<expiring_hash> known_challenges;
+std::vector<task> tasks;
+std::thread* thread;
+std::atomic<bool> solving(false);
+
+void make_keypair() {
+    ados_key = new CKey();
+    ados_key->MakeNewKey(true);
+}
+
+void solve_async() {
+    while (tasks.size() > 0) {
+        for (uint32_t i = 0; i < tasks.size(); ++i) {
+            task t = tasks[i];
+            t.o->pow->solve(0, t.investment);
+            if (t.o->pow->state == powa::solver_state::state_stopped) {
+                // solver finished
+                assert(tasks[i] == t);
+                tasks.erase(tasks.begin() + i);
+                --i;
+            }
+        }
+        solving = tasks.size() > 0;
+    }
+}
+
+void solve() {
+    if (solving) return;
+    solving = true;
+    thread = new std::thread(solve_async);
+}
+
+void begin_solving(offer_ref o, uint32_t investment) {
+    printf("- begin solving with cb %p and solver %p\n", o->pow->cb.get(), o->pow.get());
+    tasks.emplace_back(investment, o);
+    solve();
+}
+
+void challenge_peer(CNode& peer, uint32_t purpose, double pressure) {
+    printf("- challenging peer: pressure = %.4lf\n", pressure);
+    const CNetMsgMaker msgMaker(INIT_PROTO_VERSION);
+    int64_t creation = GetTime();
+    int64_t expiration = creation + 600 * (1.0 + pressure);
+    double probtgt = 1.0 / (1.0 + pressure * pressure * 15.0); // 0, 0.26, 0.37, 0.45, ..., 0.89, 0.93, 0.97, 1.0 (p = sqrt((v-1)/15))
+    uint32_t target_cmpct = arith_uint256().SetProbabilityTarget(probtgt).GetCompact(false);
+
+    powa::challenge_ref chlg(new powa::sha256challenge(target_cmpct, 0, 0, 0));
+    powa::cuckoo_cycle::cc_challenge_ref chlg2 = powa::cuckoo_cycle::cc_challenge::random_challenge();
+    powa::pow_ref alg(new powa::sha256(chlg));
+    powa::pow_ref alg2(new powa::cuckoo_cycle::cuckoo_cycle(chlg2));
+    powa::powchain chain;
+    chain.add_pow(alg);
+    chain.add_pow(alg2);
+
+    if (!ados_key) make_keypair();
+    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+    ss << chain << purpose << expiration;
+    uint256 sighash = ss.GetHash();
+    printf("outgoing challenge hash = %s\n", sighash.ToString().c_str());
+    std::vector<unsigned char> vchSig;
+    ados_key->Sign(sighash, vchSig);
+
+    g_connman.get()->PushMessage(&peer, msgMaker.Make(
+        NetMsgType::CHALLENGE,
+        chain,
+        purpose,
+        expiration,
+        vchSig
+    ));
+}
+
+bool check_challenge_hash(const int64_t expiration, uint256& sighash) {
+    int64_t now = GetTime();
+    bool result = true;
+    auto it = known_challenges.begin();
+    printf("check challenge hash for expiration %lld, hash %s\n", expiration, sighash.ToString().c_str());
+    while (it != known_challenges.end()) {
+        auto curr = it++;
+        expiring_hash eh = *curr;
+        printf("got %lld with %s\n", eh.expiration, eh.hash.ToString().c_str());
+        result &= eh.hash != sighash;
+        if (eh.expiration < now) {
+            known_challenges.erase(curr);
+        }
+    }
+    printf("challenge hash check result = %s\n", result ? "true" : "false");
+    if (result) {
+        known_challenges.insert({ expiration, sighash });
+    }
+    return result;
+}
+
+bool check_solution(offer_ref o) {
+    printf("checking solution\n");
+
+    int64_t now = GetTime();
+    if (o->expiration < now) {
+        printf("\texpired\n");
+        return false; // expired
+    }
+
+    // firstly, we determine if this is a challenge we issued that we haven't received a solution to yet
+
+    if (!ados_key) {
+        printf("\tno ados key (we have issued no challenges since startup)\n");
+        return false; // we have issued no challenges
+    }
+
+    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+    ss << *o->chain << o->purpose << o->expiration;
+    uint256 sighash = ss.GetHash();
+    printf("\tchallenge hash = %s\n", sighash.ToString().c_str());
+
+    // check challenge hash against known hashes
+    if (!check_challenge_hash(o->expiration, sighash)) {
+        printf("\tchallenge hash check failure (known hash)\n");
+        return false;
+    }
+
+    // check signature
+    if (!ados_key->GetPubKey().Verify(sighash, o->vchSig)) {
+        printf("\tsig verification failed (not our challenge)\n");
+        return false;
+    }
+
+    // we now know this is our challenge; check the solution
+    if (!o->pow->is_valid(*o->sol)) {
+        printf("\tis_valid() failed (solution invalid or does not satisfy target)\n");
+        return false;
+    }
+
+    return true;
+}
+
+double expected_solution_time(offer_ref o) {
+    int64_t cycles = o->chain->expected_iteration_cycles();
+    int64_t attempts = o->chain->expected_invprob();
+    return (cycles * attempts) / 2.195e9;
+}
+
+bool solvable(offer_ref o) {
+    double est = expected_solution_time(o);
+    int64_t eta = GetTime() + (int64_t)(est * 1.5);
+    return (eta < o->expiration);
+}
+
+}  // namespace ados

--- a/src/ados.h
+++ b/src/ados.h
@@ -1,0 +1,140 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+/**
+ * Anti-DoS mechanism using proof of work to grant temporary privileges to
+ * peers who successfully solve a given challenge. It is simultaneously an
+ * interface for solving posed challenges in order to obtain said
+ * privileges.
+ */
+
+#ifndef BITCOIN_ADOS_H
+#define BITCOIN_ADOS_H
+
+#include "protocol.h"
+#include "pow/pow.h"
+
+class CNode;
+class CAddress;
+
+namespace ados {
+
+static const uint32_t PURPOSE_CONNECT = 1;
+
+struct offer {
+    powa::pow_ref pow;
+    powa::powchain* chain;
+    powa::solution_ref sol;
+    uint32_t purpose;
+    int64_t expiration;
+    std::vector<unsigned char> vchSig;
+    bool is_challenge;
+
+    offer(bool is_challenge_in = true) : is_challenge(is_challenge_in) {}
+
+    bool operator==(const offer& other) const {
+        return pow.get() == other.pow.get() &&
+            purpose == other.purpose &&
+            expiration == other.expiration;
+    }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        if (!pow.get()) pow.reset(chain = new powa::powchain());
+        if (!sol.get()) sol.reset(new powa::solution());
+        printf("offer serializing pow %p\n", pow.get());
+        READWRITE(*chain);
+        printf("offer serializing purpose\n");
+        READWRITE(purpose);
+        READWRITE(expiration);
+        READWRITE(vchSig);
+        if (!is_challenge || !ser_action.ForRead()) READWRITE(*sol);
+        printf("offer serializing done\n");
+    }
+};
+typedef std::shared_ptr<offer> offer_ref;
+
+class callback : public powa::callback {
+public:
+    offer_ref o;
+
+    callback() {}
+    callback(offer_ref o_in) : o(o_in) {}
+
+    /**
+     * A challenge presented to us by a peer was solved.
+     * @param  challenge The challenge that was solved.
+     * @param  solution  The solution.
+     * @return           Whether the given solution satisfies external requirements. If false, another solution is attempted.
+     */
+    virtual bool solved_challenge(powa::solution_ref solution) {
+        return true; // stop finding solutions; return true here to continue searching
+    }
+
+    bool found_solution(const powa::pow& pow_, powa::challenge_ref challenge, powa::solution_ref solution) override {
+        return solved_challenge(solution);
+    }
+
+    virtual ~callback() {
+        if (o->pow.get()) o->pow->abort();
+    }
+};
+
+class connection_challenge : public callback {
+public:
+    CAddress addr;
+    connection_challenge(CNode& peer, offer_ref o_in);
+    bool solved_challenge(powa::solution_ref sol) override;
+};
+
+/**
+ * Begin to solve the challenge for the given offer. The investment
+ * defines the amount of ticks to use per attempt, before moving on to
+ * other challenges (if any).
+ * @param o          Reference to offer object.
+ * @param investment Investment (tick cap) per attempt.
+ */
+void begin_solving(offer_ref o, uint32_t investment = 10000);
+
+/**
+ * Derive a rough estimate on the estimated time to solve the challenge for the
+ * given offer.
+ * @param  o Reference to offer object.
+ * @return   An estimate in seconds.
+ */
+double expected_solution_time(offer_ref o);
+
+/**
+ * Determine if the challenge for the given offer is solvable. It is considered
+ * solvable if 1.5 times the expected solution time is less than the time until
+ * the offer expires.
+ * @param  o Reference to offer object.
+ * @return   True if the offer is most likely solvable, false if it probably isn't.
+ */
+bool solvable(offer_ref o);
+
+/**
+ * Send a CHALLENGE message to the given peer for the given purpose under the
+ * given amount of pressure. The pressure is a value between 0 and 1 which
+ * indicates how difficult the challenge should be.
+ * @param peer     The CNode peer object.
+ * @param purpose  The purpose of the challenge, e.g. PURPOSE_CONNECT.
+ * @param pressure The current pressure value, between 0 and 1.
+ */
+void challenge_peer(CNode& peer, uint32_t purpose, double pressure);
+
+/**
+ * Check if the given solution is valid. This includes making sure we signed
+ * the challenge, that it wasn't solved previously by someone else, that it
+ * isn't expired, and that its solution validly solves the challenge.
+ * @param  o Reference to offer object, which must have a solution.
+ * @return   True if the offer has been successfully solved, false otherwise.
+ */
+bool check_solution(offer_ref o);
+
+}  // namespace ados
+
+#endif  // BITCOIN_ADOS_H

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -280,6 +280,21 @@ public:
     arith_uint256& SetCompact(uint32_t nCompact, bool *pfNegative = NULL, bool *pfOverflow = NULL);
     uint32_t GetCompact(bool fNegative = false) const;
 
+    /**
+     * Set the value so that a random 256 bit digest will be smaller than this
+     * 1/pt number of times on average.
+     * @param  pt Probability target, in the range [0..1]
+     * @return    Updated self
+     */
+    arith_uint256& SetProbabilityTarget(double pt);
+
+    /**
+     * Obtain an estimate probability that a random 256 bit digest will be
+     * smaller than this.
+     * @return Probability estimate, in the range [0..1]
+     */
+    double GetProbabilityEstimate() const;
+
     friend uint256 ArithToUint256(const arith_uint256 &);
     friend arith_uint256 UintToArith256(const uint256 &);
 };

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -391,6 +391,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-listen", _("Accept connections from outside (default: 1 if no -proxy or -connect)"));
     strUsage += HelpMessageOpt("-listenonion", strprintf(_("Automatically create Tor hidden service (default: %d)"), DEFAULT_LISTEN_ONION));
     strUsage += HelpMessageOpt("-maxconnections=<n>", strprintf(_("Maintain at most <n> connections to peers (default: %u)"), DEFAULT_MAX_PEER_CONNECTIONS));
+    strUsage += HelpMessageOpt("-powconnectionslots=<n>", strprintf(_("Reserve <n> slots for proof of work challenged peers (default: %u)"), DEFAULT_POW_CONNECTION_SLOTS));
     strUsage += HelpMessageOpt("-maxreceivebuffer=<n>", strprintf(_("Maximum per-connection receive buffer, <n>*1000 bytes (default: %u)"), DEFAULT_MAXRECEIVEBUFFER));
     strUsage += HelpMessageOpt("-maxsendbuffer=<n>", strprintf(_("Maximum per-connection send buffer, <n>*1000 bytes (default: %u)"), DEFAULT_MAXSENDBUFFER));
     strUsage += HelpMessageOpt("-maxtimeadjustment", strprintf(_("Maximum allowed median peer time offset adjustment. Local perspective of time may be influenced by peers forward or backward by this amount. (default: %u seconds)"), DEFAULT_MAX_TIME_ADJUSTMENT));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -816,7 +816,9 @@ namespace { // Variables internal to initialization process only
 
 ServiceFlags nRelevantServices = NODE_NETWORK;
 int nMaxConnections;
+int nPOWConnectionSlots;
 int nUserMaxConnections;
+int nUserPOWConnectionSlots;
 int nFD;
 ServiceFlags nLocalServices = NODE_NETWORK;
 
@@ -904,6 +906,8 @@ bool AppInitParameterInteraction()
                 (gArgs.IsArgSet("-whitebind") ? gArgs.GetArgs("-whitebind").size() : 0), size_t(1));
     nUserMaxConnections = GetArg("-maxconnections", DEFAULT_MAX_PEER_CONNECTIONS);
     nMaxConnections = std::max(nUserMaxConnections, 0);
+    nUserPOWConnectionSlots = GetArg("-powconnectionslots", DEFAULT_POW_CONNECTION_SLOTS);
+    nPOWConnectionSlots = std::max(nUserPOWConnectionSlots, 0);
 
     // Trim requested connection counts, to fit into system limitations
     nMaxConnections = std::max(std::min(nMaxConnections, (int)(FD_SETSIZE - nBind - MIN_CORE_FILEDESCRIPTORS - MAX_ADDNODE_CONNECTIONS)), 0);
@@ -1649,6 +1653,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     connOptions.nLocalServices = nLocalServices;
     connOptions.nRelevantServices = nRelevantServices;
     connOptions.nMaxConnections = nMaxConnections;
+    connOptions.nPOWConnectionSlots = nPOWConnectionSlots;
     connOptions.nMaxOutbound = std::min(MAX_OUTBOUND_CONNECTIONS, connOptions.nMaxConnections);
     connOptions.nMaxAddnode = MAX_ADDNODE_CONNECTIONS;
     connOptions.nMaxFeeler = 1;

--- a/src/net.h
+++ b/src/net.h
@@ -21,6 +21,7 @@
 #include "sync.h"
 #include "uint256.h"
 #include "threadinterrupt.h"
+#include "ados.h"
 
 #include <atomic>
 #include <deque>
@@ -75,6 +76,8 @@ static const size_t MAPASKFOR_MAX_SZ = MAX_INV_SZ;
 static const size_t SETASKFOR_MAX_SZ = 2 * MAX_INV_SZ;
 /** The maximum number of peer connections to maintain. */
 static const unsigned int DEFAULT_MAX_PEER_CONNECTIONS = 125;
+/** The number of proof-of-work connection slots to retain. */
+static const unsigned int DEFAULT_POW_CONNECTION_SLOTS = 50;
 /** The default for -maxuploadtarget. 0 = Unlimited */
 static const uint64_t DEFAULT_MAX_UPLOAD_TARGET = 0;
 /** The default timeframe for -maxuploadtarget. 1 day. */
@@ -135,6 +138,7 @@ public:
         ServiceFlags nLocalServices = NODE_NONE;
         ServiceFlags nRelevantServices = NODE_NONE;
         int nMaxConnections = 0;
+        int nPOWConnectionSlots = 0;
         int nMaxOutbound = 0;
         int nMaxAddnode = 0;
         int nMaxFeeler = 0;
@@ -154,7 +158,7 @@ public:
     bool BindListenPort(const CService &bindAddr, std::string& strError, bool fWhitelisted = false);
     bool GetNetworkActive() const { return fNetworkActive; };
     void SetNetworkActive(bool active);
-    bool OpenNetworkConnection(const CAddress& addrConnect, bool fCountFailure, CSemaphoreGrant *grantOutbound = NULL, const char *strDest = NULL, bool fOneShot = false, bool fFeeler = false, bool fAddnode = false);
+    bool OpenNetworkConnection(const CAddress& addrConnect, bool fCountFailure, CSemaphoreGrant *grantOutbound = nullptr, const char *strDest = nullptr, bool fOneShot = false, bool fFeeler = false, bool fAddnode = false, const ados::offer_ref offer = nullptr);
     bool CheckIncomingNonce(uint64_t nonce);
 
     bool ForNode(NodeId id, std::function<bool(CNode* pnode)> func);
@@ -273,6 +277,15 @@ public:
     uint64_t GetTotalBytesRecv();
     uint64_t GetTotalBytesSent();
 
+    /**
+     * Calculate the pressure (work load) as a value in the range [0..1], where
+     * 0 means no pressure and 1 means maximum pressure. This is calculated as
+     *      (connections - free) / pow_slots
+     * This reaches the 1.0 point at (nMaxConnections - nMaxOutbound - nMaxFeeler).
+     * @return Pressure value.
+     */
+    double GetPressure();
+
     void SetBestHeight(int height);
     int GetBestHeight() const;
 
@@ -377,6 +390,7 @@ private:
     CSemaphore *semOutbound;
     CSemaphore *semAddnode;
     int nMaxConnections;
+    int nPOWConnectionSlots;
     int nMaxOutbound;
     int nMaxAddnode;
     int nMaxFeeler;
@@ -602,6 +616,9 @@ public:
     std::string strSubVer, cleanSubVer;
     CCriticalSection cs_SubVer; // used for both cleanSubVer and strSubVer
     bool fWhitelisted; // This peer can bypass DoS banning.
+    bool fRequirePOW; // We require this node to solve a POW challenge
+    bool fDidPOW; // This peer solved a POW challenge for us
+    ados::offer_ref offer; // An offer with a challenge that we solved for this peer
     bool fFeeler; // If true this node is being used as a short lived feeler.
     bool fOneShot;
     bool fAddnode;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -29,6 +29,7 @@
 #include "utilmoneystr.h"
 #include "utilstrencodings.h"
 #include "validationinterface.h"
+#include "ados.h"
 
 #include <boost/thread.hpp>
 
@@ -274,8 +275,16 @@ void InitializeNode(CNode *pnode, CConnman& connman) {
         LOCK(cs_main);
         mapNodeState.emplace_hint(mapNodeState.end(), std::piecewise_construct, std::forward_as_tuple(nodeid), std::forward_as_tuple(addr, std::move(addrName)));
     }
-    if(!pnode->fInbound)
+    if(!pnode->fInbound) {
+        if (pnode->offer) {
+            connman.PushMessage(pnode, CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::SOLUTION, *pnode->offer));
+            // TODO: set flag in pnode that we solved for them
+            pnode->offer = nullptr;
+        }
+        // TODO: verify that above is not at risk of arriving after below version push which would result
+        // TODO: in an invalid disconnect from the peer despite solving their challenge
         PushNodeVersion(pnode, connman, GetTime());
+    }
 }
 
 void FinalizeNode(NodeId nodeid, bool& fUpdateConnectionTime) {
@@ -1236,6 +1245,66 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 LogPrint(BCLog::NET, "Unparseable reject message received\n");
             }
         }
+    }
+
+
+    else if (strCommand == NetMsgType::SOLUTION)
+    {
+        // The node is providing us with a solution to a challenge in order to
+        // connect.
+        LogPrint(BCLog::NET, "We are being given a solution\n");
+        ados::offer_ref offer(new ados::offer(false));
+        vRecv >> *offer;
+        if (!ados::check_solution(offer)) {
+            // bye
+            LogPrint(BCLog::NET, "The provided solution did not pass. Re-challenge and disconnect.\n");
+            ados::challenge_peer(*pfrom, ados::PURPOSE_CONNECT, connman.GetPressure());
+            pfrom->fDisconnect = true;
+            return false;
+        }
+        LogPrint(BCLog::NET, "Solution passed.\n");
+        pfrom->fRequirePOW = false; // no longer required
+        pfrom->fDidPOW = true; // treat them like special snowflakes
+        return true;
+    }
+
+
+    else if (strCommand == NetMsgType::CHALLENGE)
+    {
+        // The node requires us to solve a challenge before they will talk to
+        // us.
+        LogPrint(BCLog::NET, "We are being challenged\n");
+        if (pfrom->fInbound) {
+            // we don't take challenges from incoming connections
+            LogPrint(BCLog::NET, "An inbound connection is asking us to solve a challenge to connect. Only outbound connections may do so.\n");
+            LOCK(cs_main);
+            Misbehaving(pfrom->GetId(), 10);
+            pfrom->fDisconnect = true;
+            return false;
+        }
+        ados::offer_ref offer(new ados::offer());
+        vRecv >> *offer;
+        // Is this solvable?
+        if (!ados::solvable(offer)) {
+            LogPrint(BCLog::NET, "Challenge too hard: expected solve time %.2fs\n", ados::expected_solution_time(offer));
+            return false;
+        } else {
+            LogPrint(BCLog::NET, "Solving challenge: expected solve time %.2fs; expiration in %lus\n", ados::expected_solution_time(offer), offer->expiration - GetTime());
+        }
+        offer->pow->cb.reset(new ados::connection_challenge(*pfrom, offer));
+        ados::begin_solving(offer);
+        return true;
+    }
+
+
+    else if (pfrom->fRequirePOW)
+    {
+        LogPrint(BCLog::NET, "Peer must do POW to connect; challenge and disco\n");
+        // The node did not give a solution and must solve a challenge before we
+        // will establish a connection. Challenge it and disconnect.
+        ados::challenge_peer(*pfrom, ados::PURPOSE_CONNECT, connman.GetPressure());
+        pfrom->fDisconnect = true;
+        return true;
     }
 
     else if (strCommand == NetMsgType::VERSION)

--- a/src/pow/cuckoo_cycle/LICENSE.txt
+++ b/src/pow/cuckoo_cycle/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2013-2016 John Tromp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/pow/cuckoo_cycle/cuckoo.h
+++ b/src/pow/cuckoo_cycle/cuckoo.h
@@ -7,14 +7,10 @@
 #include <stdint.h> // for types uint32_t,uint64_t
 #include <string.h> // for functions strlen, memset
 #include "siphash.h"
-// both cuckoo.c and cuckoo_miner.h need htole32
+#include "compat/endian.h"
+
 #ifdef __APPLE__
 #include "osx_barrier.h"
-#include <machine/endian.h>
-#include <libkern/OSByteOrder.h>
-#define htole32(x) OSSwapHostToLittleInt32(x)
-#else
-#include <endian.h>
 #endif
 
 namespace powa {
@@ -25,12 +21,7 @@ namespace cuckoo_cycle {
 #ifndef SIZESHIFT
 // the main parameter is the 2log of the graph size,
 // which is the size in bits of the node identifiers
-#define SIZESHIFT 20
-#endif
-#ifndef PROOFSIZE
-// the next most important parameter is (even) length
-// of the cycle to be found. a minimum of 12 is recommended
-#define PROOFSIZE 42
+#define SIZESHIFT 28
 #endif
 
 // the graph size / number of nodes
@@ -41,49 +32,66 @@ static const u64 HALFSIZE = SIZE/2;
 static const u64 NODEMASK = HALFSIZE-1;
 
 // generate edge endpoint in cuckoo graph without partition bit
-u64 _sipnode(siphash_keys *keys, u64 nonce, u32 uorv) {
+inline u64 _sipnode(siphash_keys *keys, u64 nonce, u32 uorv) {
   return siphash24(keys, 2*nonce + uorv) & NODEMASK;
 }
 
 // generate edge endpoint in cuckoo graph
-u64 sipnode(siphash_keys *keys, u64 nonce, u32 uorv) {
+inline u64 sipnode(siphash_keys *keys, u64 nonce, u32 uorv) {
   return _sipnode(keys, nonce, uorv) << 1 | uorv;
 }
 
 enum verify_code { POW_OK, POW_HEADER_LENGTH, POW_TOO_BIG, POW_TOO_SMALL, POW_NON_MATCHING, POW_BRANCH, POW_DEAD_END, POW_SHORT_CYCLE};
-const char *errstr[] = { "OK", "wrong header length", "proof too big", "proof too small", "endpoints don't match up", "branch in cycle", "cycle dead ends", "cycle too short"};
+static const char *errstr[] = { "OK", "wrong header length", "proof too big", "proof too small", "endpoints don't match up", "branch in cycle", "cycle dead ends", "cycle too short"};
 
 // verify that nonces are ascending and form a cycle in header-generated graph
-int verify(u32 nonces[PROOFSIZE], const char *headernonce, const u32 headerlen) {
+inline int verify(u32* nonces, const char *headernonce, const u32 headerlen, const uint16_t proofsize) {
   if (headerlen != HEADERLEN)
     return POW_HEADER_LENGTH;
   siphash_keys keys;
   setheader(&keys, headernonce);
-  u32 uvs[2*PROOFSIZE];
+  u32* uvs = new u32[2*proofsize];
   u32 xor0=0,xor1=0;
-  for (u32 n = 0; n < PROOFSIZE; n++) {
-    if (nonces[n] >= HALFSIZE)
-      return POW_TOO_BIG;
-    if (n && nonces[n] <= nonces[n-1])
-      return POW_TOO_SMALL;
-    xor0 ^= uvs[2*n  ] = sipnode(&keys, nonces[n], 0);
-    xor1 ^= uvs[2*n+1] = sipnode(&keys, nonces[n], 1);
+  int err = POW_OK;
+  for (u32 n = 0; err == POW_OK && n < proofsize; n++) {
+    if (nonces[n] >= HALFSIZE) {
+      err = POW_TOO_BIG;
+    } else if (n && nonces[n] <= nonces[n-1]) {
+      err = POW_TOO_SMALL;
+    } else {
+      xor0 ^= uvs[2*n  ] = sipnode(&keys, nonces[n], 0);
+      xor1 ^= uvs[2*n+1] = sipnode(&keys, nonces[n], 1);
+    }
   }
-  if (xor0|xor1)                        // matching endpoints imply zero xors
+  if (err != POW_OK) {
+    delete [] uvs;
+    return err;
+  }
+  if (xor0|xor1) {                      // matching endpoints imply zero xors
+    delete [] uvs;
     return POW_NON_MATCHING;
+  }
   u32 n = 0, i = 0, j;
   do {                        // follow cycle
-    for (u32 k = j = i; (k = (k+2) % (2*PROOFSIZE)) != i; ) {
+    for (u32 k = j = i; (k = (k+2) % (2*proofsize)) != i; ) {
       if (uvs[k] == uvs[i]) { // find other edge endpoint identical to one at i
-        if (j != i)           // already found one before
+        if (j != i) {          // already found one before
+          delete [] uvs;
           return POW_BRANCH;
+        }
         j = k;
       }
-    } if (j == i) return POW_DEAD_END;  // no matching endpoint
+    }
+    if (j == i) {
+      // no matching endpoint
+      delete [] uvs;
+      return POW_DEAD_END;
+    }
     i = j^1;
     n++;
   } while (i != 0);           // must cycle back to start or we would have found branch
-  return n == PROOFSIZE ? POW_OK : POW_SHORT_CYCLE;
+  delete [] uvs;
+  return n == proofsize ? POW_OK : POW_SHORT_CYCLE;
 }
 
 }  // namespace cuckoo_cycle

--- a/src/pow/cuckoo_cycle/cuckoo.h
+++ b/src/pow/cuckoo_cycle/cuckoo.h
@@ -1,0 +1,93 @@
+// Cuckoo Cycle, a memory-hard proof-of-work
+// Copyright (c) 2013-2016 John Tromp
+
+#ifndef BITCOIN_POW_CUCKOO_CYCLE_CUCKOO_H
+#define BITCOIN_POW_CUCKOO_CYCLE_CUCKOO_H
+
+#include <stdint.h> // for types uint32_t,uint64_t
+#include <string.h> // for functions strlen, memset
+#include "siphash.h"
+// both cuckoo.c and cuckoo_miner.h need htole32
+#ifdef __APPLE__
+#include "osx_barrier.h"
+#include <machine/endian.h>
+#include <libkern/OSByteOrder.h>
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#else
+#include <endian.h>
+#endif
+
+namespace powa {
+
+namespace cuckoo_cycle {
+
+// proof-of-work parameters
+#ifndef SIZESHIFT
+// the main parameter is the 2log of the graph size,
+// which is the size in bits of the node identifiers
+#define SIZESHIFT 20
+#endif
+#ifndef PROOFSIZE
+// the next most important parameter is (even) length
+// of the cycle to be found. a minimum of 12 is recommended
+#define PROOFSIZE 42
+#endif
+
+// the graph size / number of nodes
+static const u64 SIZE = 1ULL<<SIZESHIFT;
+// number of nodes in one partition (eg. all even nodes)
+static const u64 HALFSIZE = SIZE/2;
+// used to mask siphash output
+static const u64 NODEMASK = HALFSIZE-1;
+
+// generate edge endpoint in cuckoo graph without partition bit
+u64 _sipnode(siphash_keys *keys, u64 nonce, u32 uorv) {
+  return siphash24(keys, 2*nonce + uorv) & NODEMASK;
+}
+
+// generate edge endpoint in cuckoo graph
+u64 sipnode(siphash_keys *keys, u64 nonce, u32 uorv) {
+  return _sipnode(keys, nonce, uorv) << 1 | uorv;
+}
+
+enum verify_code { POW_OK, POW_HEADER_LENGTH, POW_TOO_BIG, POW_TOO_SMALL, POW_NON_MATCHING, POW_BRANCH, POW_DEAD_END, POW_SHORT_CYCLE};
+const char *errstr[] = { "OK", "wrong header length", "proof too big", "proof too small", "endpoints don't match up", "branch in cycle", "cycle dead ends", "cycle too short"};
+
+// verify that nonces are ascending and form a cycle in header-generated graph
+int verify(u32 nonces[PROOFSIZE], const char *headernonce, const u32 headerlen) {
+  if (headerlen != HEADERLEN)
+    return POW_HEADER_LENGTH;
+  siphash_keys keys;
+  setheader(&keys, headernonce);
+  u32 uvs[2*PROOFSIZE];
+  u32 xor0=0,xor1=0;
+  for (u32 n = 0; n < PROOFSIZE; n++) {
+    if (nonces[n] >= HALFSIZE)
+      return POW_TOO_BIG;
+    if (n && nonces[n] <= nonces[n-1])
+      return POW_TOO_SMALL;
+    xor0 ^= uvs[2*n  ] = sipnode(&keys, nonces[n], 0);
+    xor1 ^= uvs[2*n+1] = sipnode(&keys, nonces[n], 1);
+  }
+  if (xor0|xor1)                        // matching endpoints imply zero xors
+    return POW_NON_MATCHING;
+  u32 n = 0, i = 0, j;
+  do {                        // follow cycle
+    for (u32 k = j = i; (k = (k+2) % (2*PROOFSIZE)) != i; ) {
+      if (uvs[k] == uvs[i]) { // find other edge endpoint identical to one at i
+        if (j != i)           // already found one before
+          return POW_BRANCH;
+        j = k;
+      }
+    } if (j == i) return POW_DEAD_END;  // no matching endpoint
+    i = j^1;
+    n++;
+  } while (i != 0);           // must cycle back to start or we would have found branch
+  return n == PROOFSIZE ? POW_OK : POW_SHORT_CYCLE;
+}
+
+}  // namespace cuckoo_cycle
+
+}  // namespace powa
+
+#endif  // BITCOIN_POW_CUCKOO_CYCLE_CUCKOO_H

--- a/src/pow/cuckoo_cycle/cuckoo_cycle.cpp
+++ b/src/pow/cuckoo_cycle/cuckoo_cycle.cpp
@@ -1,0 +1,101 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "cuckoo_cycle.h"
+
+#include <algorithm>
+
+#include "../random.h"
+
+namespace powa {
+
+namespace cuckoo_cycle {
+
+int cuckoo_cycle::last_err = POW_OK;
+
+cuckoo_cycle::~cuckoo_cycle() {
+    if (thread) {
+        if (state == state_running) {
+            state = state_term;
+            thread->join();
+        }
+        delete thread;
+        thread = nullptr;
+    }
+}
+
+void cuckoo_cycle::solve(uint32_t threads, bool background, int32_t ticks) {
+    assert(state == state_ready || state == state_paused);
+    if (state == state_ready && !fZeroStartingNonce) {
+        // randomize nonce
+        GetRandBytes((unsigned char*)&next_nonce, sizeof(next_nonce));
+    }
+    state = state_running;
+    ticks_left = ticks;
+    if (c->params.size() != HEADERLEN - 4) {
+        c->params.resize(HEADERLEN - 4);
+    }
+    if (background) {
+        thread = new std::thread(&cuckoo_cycle::solve_async, this, threads ?: 1);
+    } else {
+        solve_async(threads ?: 1);
+    }
+}
+
+void cuckoo_cycle::abort() {
+    if (state != state_running) return;
+    state = state_term;
+    thread->join();
+}
+
+void cuckoo_cycle::solve_async(uint32_t thread_count) { // asynchronous
+    int ntrims = 1 + (PART_BITS+3)*(PART_BITS+4)/2;
+    int nonce  = next_nonce;
+    thread_ctx* threads = new thread_ctx[thread_count];
+    assert(threads);
+    size_t wx = std::min((size_t)80, c->params.size() + 4);
+    char* ws = new char[wx];
+    memcpy(ws, &c->params[0], c->params.size());
+    ctx = new cuckoo_ctx(thread_count, ntrims, 8, c->proofsize_min, c->proofsize_max);
+    while (state == state_running) {
+        ctx->setheadernonce(ws, wx, nonce);
+        for (uint32_t t = 0; t < thread_count; t++) {
+            threads[t].id = t;
+            threads[t].ctx = ctx;
+            int err = pthread_create(&threads[t].thread, nullptr, worker, (void*)&threads[t]);
+            assert(err == 0);
+        }
+        for (uint32_t t = 0; t < thread_count; t++) {
+            int err = pthread_join(threads[t].thread, nullptr);
+            assert(err == 0);
+        }
+        // if we are aborted due to deallocation we don't want to talk to callback
+        // even if we have solutions, so we break on term
+        if (state != state_running) break;
+        for (unsigned s = 0; s < ctx->nsols; s++) {
+            nonce_t proofsize = ctx->sols[s][ctx->proofsize_max];
+            printf("- solution with proofsize = %u found for nonce = %d\n", proofsize, nonce);
+            solution_ref sol(new solution());
+            sol->params.resize(4 * (1 + proofsize));
+            SetNonce(sol, nonce);
+            SetKeys(sol, ctx->sols[s], proofsize);
+            if (cb->found_solution(*this, c, sol)) {
+                state = state_stopped;
+                break;
+            }
+        }
+        nonce++;
+        ticks_left -= ticks_left > -1;
+        if (ticks_left == 0) state = state_paused;
+    }
+    if (state == state_term) state = state_aborted;
+    delete ctx;
+    delete [] ws;
+    delete [] threads;
+    next_nonce = nonce;
+}
+
+}  // namespace cuckoo_cycle
+
+}  // namespace powa

--- a/src/pow/cuckoo_cycle/cuckoo_cycle.h
+++ b/src/pow/cuckoo_cycle/cuckoo_cycle.h
@@ -1,0 +1,134 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_POW_CUCKOO_CYCLE_H
+#define BITCOIN_POW_CUCKOO_CYCLE_H
+
+#include <thread>
+
+#include "pow/pow.h"
+#include "cuckoo_miner.h"
+
+namespace powa {
+
+namespace cuckoo_cycle {
+
+class cc_challenge;
+
+typedef std::shared_ptr<cc_challenge> cc_challenge_ref;
+
+class cc_challenge : public challenge {
+public:
+    using challenge::challenge;
+    uint8_t sizeshift;
+    uint16_t proofsize_min;
+    uint16_t proofsize_max;
+
+    cc_challenge() : challenge() {
+        config.params.resize(5);
+        uint8_t* configb = &config.params[0];
+        *configb = sizeshift = SIZESHIFT;
+        configb += 1;
+        *(uint16_t*)configb = proofsize_min = 12;
+        configb += 2;
+        *(uint16_t*)configb = proofsize_max = 228;
+    }
+
+    cc_challenge(const challenge& other) : challenge(other) {
+        assert(config.params.size() == 5);
+        uint8_t* configb = &config.params[0];
+        sizeshift = *configb;
+        // TODO: deal with the fact we don't support certain size shifts; currently this is ignored
+        configb += 1;
+        proofsize_min = *(uint16_t*)configb;
+        configb += 2;
+        proofsize_max = *(uint16_t*)configb;
+        // TODO: validate proofsizes; must be even, max must >= min, ...
+    }
+
+    static cc_challenge_ref random_challenge(const uint8_t len = HEADERLEN - 4) {
+        cc_challenge* c = new cc_challenge();
+        c->params.resize(len);
+        c->randomize(c->params.size());
+        return cc_challenge_ref(c);
+    }
+
+    cc_challenge& operator=(const cc_challenge& other) {
+        params = other.params;
+        return *this;
+    }
+
+    bool operator==(const cc_challenge& other) const {
+        return !memcmp(&params[0], &other.params[0], params.size());
+    }
+};
+
+inline uint32_t GetNonce(solution_ref& s) { return *(uint32_t*)&s->params[0]; }
+inline uint32_t* GetKeys(solution_ref& s) { return &((uint32_t*)&s->params[0])[1]; }
+inline void SetNonce(solution_ref& s, uint32_t nonce) { memcpy(&s->params[0], &nonce, 4); }
+inline void SetKeys(solution_ref& s, uint32_t* keys, uint16_t count) { memcpy(&s->params[4], keys, count * 4); }
+
+class cuckoo_cycle : public pow {
+public:
+    std::thread* thread;
+    cc_challenge_ref c;
+    cuckoo_ctx* ctx;
+    int next_nonce;
+    static int last_err;               ///< last error after call to is_valid()
+    cuckoo_cycle(cc_challenge_ref c_in, callback_ref cb_in = nullptr) : pow(POWID_CUCKOO_CYCLE, c_in, cb_in), thread(nullptr), c(c_in), next_nonce(0) {}
+    ~cuckoo_cycle();
+
+    std::string last_error_string() {
+        return errstr[last_err];
+    }
+
+    bool is_valid(solution& s) const override {
+        if (s.params.size() < size_t(1 + c->proofsize_min) * 4 ||
+            s.params.size() > size_t(1 + c->proofsize_max) * 4) {
+            return false; // 1 nonce + edges, all 32 bit
+        }
+        u32* values = (u32*)&s.params[0];
+        u32 nonce = values[0];
+        u32* keys = &values[1];
+        uint16_t proofsize = (s.params.size() >> 2) - 1;
+        printf("CC is_valid(): nonce=%u, proofsize=%u\n", nonce, proofsize);
+
+        char headernonce[HEADERLEN];
+        u32 hdrlen = c.get()->params.size();
+        memcpy(headernonce, &c.get()->params[0], hdrlen);
+        if (hdrlen < sizeof(headernonce)) memset(headernonce + hdrlen, 0, sizeof(headernonce) - hdrlen);
+        ((u32 *)headernonce)[HEADERLEN/sizeof(u32)-1] = htole32(nonce);
+
+        last_err = verify(keys, headernonce, HEADERLEN, proofsize);
+        return (last_err == POW_OK);
+    }
+
+    void set_output(solution& s, std::vector<uint8_t>& output) override {
+        // the output for a CC POW is the solution in full
+        output.resize(s.params.size());
+        memcpy(&output[0], &s.params[0], s.params.size());
+    }
+
+    void solve(uint32_t threads = 0, bool background = false, int32_t ticks = -1) override;
+
+    int64_t expected_iteration_cycles() const override { return 150000000000; }
+    int64_t expected_invprob()          const override {
+        // we require 12/228 at this point, or we expect a 1/999 probability of solving
+        return c->proofsize_min == 12 && c->proofsize_max == 228 ? 1 : 999;
+    }
+
+    void abort() override;
+
+    virtual std::string to_string() const override {
+        return strprintf("Cuckoo-Cycle<%p; ps=[%u, %u]>", this, c->proofsize_min, c->proofsize_max);
+    }
+private:
+    void solve_async(uint32_t thread_count);
+};
+
+}  // namespace cuckoo_cycle
+
+}  // namespace powa
+
+#endif  // BITCOIN_POW_CUCKOO_CYCLE_H

--- a/src/pow/cuckoo_cycle/cuckoo_miner.h
+++ b/src/pow/cuckoo_cycle/cuckoo_miner.h
@@ -1,0 +1,486 @@
+// Cuckoo Cycle, a memory-hard proof-of-work
+// Copyright (c) 2013-2016 John Tromp
+// The edge-trimming memory optimization is due to Dave Andersen
+// http://da-data.blogspot.com/2014/03/a-public-review-of-cuckoo-cycle.html
+// The use of prefetching was suggested by Alexander Peslyak (aka Solar Designer)
+// define SINGLECYCLING to run cycle finding single threaded which runs slower
+// but avoids losing cycles to race conditions (not worth it in my testing)
+
+#ifndef BITCOIN_POW_CUCKOO_CYCLE_CUCKOO_MINER_H
+#define BITCOIN_POW_CUCKOO_CYCLE_CUCKOO_MINER_H
+
+#include "cuckoo.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <assert.h>
+#include <set>
+
+#ifdef ATOMIC
+#include <atomic>
+#endif
+
+namespace powa {
+
+namespace cuckoo_cycle {
+
+#ifdef ATOMIC
+typedef std::atomic<u32> au32;
+typedef std::atomic<u64> au64;
+#else
+typedef u32 au32;
+typedef u64 au64;
+#endif
+
+#ifndef SIZEOF_TWICE_ATOM
+#define SIZEOF_TWICE_ATOM 4
+#endif
+#if SIZEOF_TWICE_ATOM == 8
+typedef au64 atwice;
+typedef u64 uatwice;
+#elif SIZEOF_TWICE_ATOM == 4
+typedef au32 atwice;
+typedef u32 uatwice;
+#elif SIZEOF_TWICE_ATOM == 1
+typedef unsigned char atwice;
+typedef unsigned char uatwice;
+#else
+#error not implemented
+#endif
+
+#if SIZESHIFT <= 32
+typedef u32 nonce_t;
+typedef u32 node_t;
+#else
+typedef u64 nonce_t;
+typedef u64 node_t;
+#endif
+
+// algorithm/performance parameters
+#ifndef PART_BITS
+// #bits used to partition edge set processing to save memory
+// a value of 0 does no partitioning and is fastest
+// a value of 1 partitions in two, making twice_set the
+// same size as shrinkingset at about 33% slowdown
+// higher values are not that interesting
+#define PART_BITS 0
+#endif
+
+#ifndef NPREFETCH
+// how many prefetches to queue up
+// before accessing the memory
+// must be a multiple of NSIPHASH
+#define NPREFETCH 32
+#endif
+
+#ifndef IDXSHIFT
+// we want sizeof(cuckoo_hash) == sizeof(twice_set), so
+// CUCKOO_SIZE * sizeof(u64)   == 2 * ONCE_BITS / 32
+// CUCKOO_SIZE * 2             == 2 * ONCE_BITS / 32
+// (SIZE >> IDXSHIFT) * 2      == 2 * ONCE_BITS / 32
+// SIZE >> IDXSHIFT            == HALFSIZE >> PART_BITS >> 5
+// IDXSHIFT                    == 1 + PART_BITS + 5
+#define IDXSHIFT (PART_BITS + 6)
+#endif
+// grow with cube root of size, hardly affected by trimming
+const static u32 MAXCCPATHLEN = 8 << (SIZESHIFT/3);
+
+const static u32 PART_MASK = (1 << PART_BITS) - 1;
+const static u64 ONCE_BITS = HALFSIZE >> PART_BITS;
+const static u64 TWICE_BYTES = (2 * ONCE_BITS) / 8;
+const static u64 TWICE_ATOMS = TWICE_BYTES / sizeof(atwice);
+const static u32 TWICE_PER_ATOM = sizeof(atwice) * 4;
+
+class twice_set {
+public:
+  atwice *bits;
+
+  twice_set() {
+    bits = (atwice *)calloc(TWICE_ATOMS, sizeof(atwice));
+    assert(bits != 0);
+  }
+  void clear() {
+    assert(bits);
+    memset(bits, 0, TWICE_ATOMS*sizeof(atwice));
+  }
+ void prefetch(node_t u) const {
+#ifdef PREFETCH
+    __builtin_prefetch((const void *)(&bits[u/TWICE_PER_ATOM]), /*READ=*/0, /*TEMPORAL=*/0);
+#endif
+  }
+  void set(node_t u) {
+    node_t idx = u/TWICE_PER_ATOM;
+    uatwice bit = (uatwice)1 << (2 * (u%TWICE_PER_ATOM));
+#ifdef ATOMIC
+    uatwice old = std::atomic_fetch_or_explicit(&bits[idx], bit, std::memory_order_relaxed);
+    if (old & bit) std::atomic_fetch_or_explicit(&bits[idx], bit<<1, std::memory_order_relaxed);
+#else
+    uatwice old = bits[idx];
+    bits[idx] = old | (bit + (old & bit));
+#endif
+  }
+  bool test(node_t u) const {
+#ifdef ATOMIC
+    return ((bits[u/TWICE_PER_ATOM].load(std::memory_order_relaxed)
+            >> (2 * (u%TWICE_PER_ATOM))) & 2) != 0;
+#else
+    return (bits[u/TWICE_PER_ATOM] >> (2 * (u%TWICE_PER_ATOM)) & 2) != 0;
+#endif
+  }
+  ~twice_set() {
+    free(bits);
+  }
+};
+
+// set that starts out full and gets reset by threads on disjoint words
+class shrinkingset {
+public:
+  u64 *bits;
+  u64 *cnt;
+  u32 nthreads;
+
+  shrinkingset(const u32 nt) {
+    bits = (u64 *)malloc(HALFSIZE/8);
+    cnt  = (u64 *)malloc(nt * sizeof(u64));
+    nthreads = nt;
+  }
+  void clear() {
+    memset(bits, 0, HALFSIZE/8);
+    memset(cnt, 0, nthreads * sizeof(u64));
+    cnt[0] = HALFSIZE;
+  }
+  u64 count() const {
+    u64 sum = 0LL;
+    for (u32 i=0; i<nthreads; i++)
+      sum += cnt[i];
+    return sum;
+  }
+  void reset(nonce_t n, u32 thread) {
+    bits[n/64] |= 1LL << (n%64);
+    cnt[thread]--;
+  }
+  bool test(node_t n) const {
+    return !((bits[n/64] >> (n%64)) & 1LL);
+  }
+  u64 block(node_t n) const {
+    return ~bits[n/64];
+  }
+};
+
+const static u64 CUCKOO_SIZE = SIZE >> IDXSHIFT;
+const static u64 CUCKOO_MASK = CUCKOO_SIZE - 1;
+// number of (least significant) key bits that survives leftshift by SIZESHIFT
+const static u32 KEYBITS = 64-SIZESHIFT;
+const static u64 KEYMASK = (1LL << KEYBITS) - 1;
+const static u64 MAXDRIFT = 1LL << (KEYBITS - IDXSHIFT);
+
+class cuckoo_hash {
+public:
+  au64 *cuckoo;
+
+  cuckoo_hash(void *recycle) {
+    cuckoo = (au64 *)recycle;
+    memset(cuckoo, 0, CUCKOO_SIZE*sizeof(au64));
+  }
+  void set(node_t u, node_t v) {
+    u64 niew = (u64)u << SIZESHIFT | v;
+    for (node_t ui = u >> IDXSHIFT; ; ui = (ui+1) & CUCKOO_MASK) {
+#if !defined(SINGLECYCLING) && defined(ATOMIC)
+      u64 old = 0;
+      if (cuckoo[ui].compare_exchange_strong(old, niew, std::memory_order_relaxed))
+        return;
+      if ((old >> SIZESHIFT) == (u & KEYMASK)) {
+        cuckoo[ui].store(niew, std::memory_order_relaxed);
+        return;
+      }
+#else
+      u64 old = cuckoo[ui];
+      if (old == 0 || (old >> SIZESHIFT) == (u & KEYMASK)) {
+        cuckoo[ui] = niew;
+        return;
+      }
+#endif
+    }
+  }
+  node_t operator[](node_t u) const {
+    for (node_t ui = u >> IDXSHIFT; ; ui = (ui+1) & CUCKOO_MASK) {
+#if !defined(SINGLECYCLING) && defined(ATOMIC)
+      u64 cu = cuckoo[ui].load(std::memory_order_relaxed);
+#else
+      u64 cu = cuckoo[ui];
+#endif
+      if (!cu)
+        return 0;
+      if ((cu >> SIZESHIFT) == (u & KEYMASK)) {
+        assert(((ui - (u >> IDXSHIFT)) & CUCKOO_MASK) < MAXDRIFT);
+        return (node_t)(cu & (SIZE-1));
+      }
+    }
+  }
+};
+
+class cuckoo_ctx {
+public:
+  siphash_keys sip_keys;
+  shrinkingset *alive;
+  twice_set *nonleaf;
+  cuckoo_hash *cuckoo;
+  nonce_t (*sols)[PROOFSIZE];
+  u32 maxsols;
+  au32 nsols;
+  u32 nthreads;
+  u32 ntrims;
+  pthread_barrier_t barry;
+
+  cuckoo_ctx(u32 n_threads, u32 n_trims, u32 max_sols) {
+    nthreads = n_threads;
+    alive = new shrinkingset(nthreads);
+    cuckoo = 0;
+    nonleaf = new twice_set;
+    ntrims = n_trims;
+    int err = pthread_barrier_init(&barry, NULL, nthreads);
+    assert(err == 0);
+    sols = (nonce_t (*)[PROOFSIZE])calloc(maxsols = max_sols, PROOFSIZE*sizeof(nonce_t));
+    assert(sols != 0);
+    nsols = 0;
+  }
+  void setheadernonce(char* headernonce, const u32 len, const u32 nonce) {
+    ((u32 *)headernonce)[len/sizeof(u32)-1] = htole32(nonce); // place nonce at end
+    setheader(&sip_keys, headernonce);
+    alive->clear(); // set all edges to be alive
+    nsols = 0;
+  }
+  ~cuckoo_ctx() {
+    delete alive;
+    delete nonleaf;
+    delete cuckoo;
+  }
+  void prefetch(const u64 *hashes, const u32 part) const {
+    for (u32 i=0; i < NSIPHASH; i++) {
+      u32 u = hashes[i] & NODEMASK;
+      if ((u & PART_MASK) == part) {
+        nonleaf->prefetch(u >> PART_MASK);
+      }
+    }
+  }
+  void node_deg(const u64 *hashes, const u32 nsiphash, const u32 part) const {
+    for (u32 i=0; i < nsiphash; i++) {
+      u32 u = hashes[i] & NODEMASK;
+      if ((u & PART_MASK) == part) {
+        nonleaf->set(u >>= PART_BITS);
+      }
+    }
+  }
+  void count_node_deg(const u32 id, const u32 uorv, const u32 part) {
+    alignas(64) u64 indices[NSIPHASH];
+    alignas(64) u64 hashes[NPREFETCH];
+
+    memset(hashes, 0, NPREFETCH * sizeof(u64)); // allow many nonleaf->set(0) to reduce branching
+    u32 nidx = 0;
+    for (nonce_t block = id*64; block < HALFSIZE; block += nthreads*64) {
+      u64 alive64 = alive->block(block);
+      for (nonce_t nonce = block-1; alive64; ) { // -1 compensates for 1-based ffs
+        u32 ffs = __builtin_ffsll(alive64);
+        nonce += ffs; alive64 >>= ffs;
+        indices[nidx++ % NSIPHASH] = 2*nonce + uorv;
+        if (nidx % NSIPHASH == 0) {
+          node_deg(hashes+nidx-NSIPHASH, NSIPHASH, part);
+          siphash24xN(&sip_keys, indices, hashes+nidx-NSIPHASH);
+          prefetch(hashes+nidx-NSIPHASH, part);
+          nidx %= NPREFETCH;
+        }
+        if (ffs & 64) break; // can't shift by 64
+      }
+    }
+    node_deg(hashes, NPREFETCH, part);
+    if (nidx % NSIPHASH != 0) {
+      siphash24xN(&sip_keys, indices, hashes+(nidx&-NSIPHASH));
+      node_deg(hashes+(nidx&-NSIPHASH), nidx%NSIPHASH, part);
+    }
+  }
+  void kill(const u64 *hashes, const u64 *indices, const u32 nsiphash,
+             const u32 part, const u32 id) const {
+    for (u32 i=0; i < nsiphash; i++) {
+      u32 u = hashes[i] & NODEMASK;
+      if ((u & PART_MASK) == part && !nonleaf->test(u >> PART_BITS)) {
+        alive->reset(indices[i]/2, id);
+      }
+    }
+  }
+  void kill_leaf_edges(const u32 id, const u32 uorv, const u32 part) {
+    alignas(64) u64 indices[NPREFETCH];
+    alignas(64) u64 hashes[NPREFETCH];
+
+    memset(hashes, 0, NPREFETCH * sizeof(u64)); // allow many nonleaf->test(0) to reduce branching
+    u32 nidx = 0;
+    for (nonce_t block = id*64; block < HALFSIZE; block += nthreads*64) {
+      u64 alive64 = alive->block(block);
+      for (nonce_t nonce = block-1; alive64; ) { // -1 compensates for 1-based ffs
+        u32 ffs = __builtin_ffsll(alive64);
+        nonce += ffs; alive64 >>= ffs;
+        indices[nidx++] = 2*nonce + uorv;
+        if (nidx % NSIPHASH == 0) {
+          siphash24xN(&sip_keys, indices+nidx-NSIPHASH, hashes+nidx-NSIPHASH);
+          prefetch(hashes+nidx-NSIPHASH, part);
+          nidx %= NPREFETCH;
+          kill(hashes+nidx, indices+nidx, NSIPHASH, part, id);
+        }
+        if (ffs & 64) break; // can't shift by 64
+      }
+    }
+    const u32 pnsip = nidx & -NSIPHASH;
+    if (pnsip != nidx) {
+      siphash24xN(&sip_keys, indices+pnsip, hashes+pnsip);
+    }
+    kill(hashes, indices, nidx, part, id);
+    const u32 nnsip = pnsip + NSIPHASH;
+    kill(hashes+nnsip, indices+nnsip, NPREFETCH-nnsip, part, id);
+  }
+  void solution(node_t *us, u32 nu, node_t *vs, u32 nv) {
+    typedef std::pair<node_t,node_t> edge;
+    std::set<edge> cycle;
+    u32 n = 0;
+    cycle.insert(edge(*us, *vs));
+    while (nu--)
+      cycle.insert(edge(us[(nu+1)&~1], us[nu|1])); // u's in even position; v's in odd
+    while (nv--)
+      cycle.insert(edge(vs[nv|1], vs[(nv+1)&~1])); // u's in odd position; v's in even
+  #ifdef ATOMIC
+    u32 soli = std::atomic_fetch_add_explicit(&nsols, 1U, std::memory_order_relaxed);
+  #else
+    u32 soli = nsols++;
+  #endif
+    for (nonce_t block = 0; block < HALFSIZE; block += 64) {
+      u64 alive64 = alive->block(block);
+      for (nonce_t nonce = block-1; alive64; ) { // -1 compensates for 1-based ffs
+        u32 ffs = __builtin_ffsll(alive64);
+        nonce += ffs; alive64 >>= ffs;
+        edge e(sipnode(&sip_keys, nonce, 0), sipnode(&sip_keys, nonce, 1));
+        if (cycle.find(e) != cycle.end()) {
+          sols[soli][n++] = nonce;
+  #ifdef SHOWSOL
+          printf("e(%x)=(%x,%x)%c", nonce, e.first, e.second, n==PROOFSIZE?'\n':' ');
+  #endif
+          if (PROOFSIZE > 2)
+            cycle.erase(e);
+        }
+        if (ffs & 64) break; // can't shift by 64
+      }
+    }
+    assert(n==PROOFSIZE);
+  }
+};
+
+typedef struct {
+  u32 id;
+  pthread_t thread;
+  cuckoo_ctx *ctx;
+} thread_ctx;
+
+void barrier(pthread_barrier_t *barry) {
+  int rc = pthread_barrier_wait(barry);
+  if (rc != 0 && rc != PTHREAD_BARRIER_SERIAL_THREAD) {
+    printf("Could not wait on barrier\n");
+    pthread_exit(NULL);
+  }
+}
+
+u32 path(cuckoo_hash &cuckoo, node_t u, node_t *us) {
+  u32 nu;
+  for (nu = 0; u; u = cuckoo[u]) {
+    if (nu >= MAXCCPATHLEN) {
+      while (nu-- && us[nu] != u) ;
+      // if (!~nu)
+      //   printf("maximum path length exceeded\n");
+      // else printf("illegal %4d-cycle\n", MAXCCPATHLEN-nu);
+      pthread_exit(NULL);
+    }
+    us[nu++] = u;
+  }
+  return nu-1;
+}
+
+void *worker(void *vp) {
+  thread_ctx *tp = (thread_ctx *)vp;
+  cuckoo_ctx *ctx = tp->ctx;
+
+  shrinkingset *alive = ctx->alive;
+  u32 load = 100LL * HALFSIZE / CUCKOO_SIZE;
+  // if (tp->id == 0)
+  //   printf("initial load %d%%\n", load);
+  for (u32 round=1; round <= ctx->ntrims; round++) {
+    // if (tp->id == 0) printf("round %2d partition loads", round);
+    for (u32 uorv = 0; uorv < 2; uorv++) {
+      for (u32 part = 0; part <= PART_MASK; part++) {
+        if (tp->id == 0)
+          ctx->nonleaf->clear(); // clear all counts
+        barrier(&ctx->barry);
+        ctx->count_node_deg(tp->id,uorv,part);
+        barrier(&ctx->barry);
+        ctx->kill_leaf_edges(tp->id,uorv,part);
+        barrier(&ctx->barry);
+        // if (tp->id == 0) {
+        //   u32 load = (u32)(100LL * alive->count() / CUCKOO_SIZE);
+        //   printf(" %c%d %4d%%", "UV"[uorv], part, load);
+        // }
+      }
+    }
+    // if (tp->id == 0) printf("\n");
+  }
+  if (tp->id == 0) {
+    load = (u32)(100LL * alive->count() / CUCKOO_SIZE);
+    // printf("nonce %d: %d trims completed  final load %d%%\n", ctx->nonce, ctx->ntrims, load);
+    if (load >= 90) {
+      printf("overloaded! exiting...");
+      pthread_exit(NULL);
+    }
+    ctx->cuckoo = new cuckoo_hash(ctx->nonleaf->bits);
+  }
+#ifdef SINGLECYCLING
+  else pthread_exit(NULL);
+#else
+  barrier(&ctx->barry);
+#endif
+  cuckoo_hash &cuckoo = *ctx->cuckoo;
+  node_t us[MAXCCPATHLEN], vs[MAXCCPATHLEN];
+#ifdef SINGLECYCLING
+  for (nonce_t block = 0; block < HALFSIZE; block += 64) {
+#else
+  for (nonce_t block = tp->id*64; block < HALFSIZE; block += ctx->nthreads*64) {
+#endif
+    u64 alive64 = alive->block(block);
+    for (nonce_t nonce = block-1; alive64; ) { // -1 compensates for 1-based ffs
+      u32 ffs = __builtin_ffsll(alive64);
+      nonce += ffs; alive64 >>= ffs;
+      node_t u0=sipnode(&ctx->sip_keys, nonce, 0), v0=sipnode(&ctx->sip_keys, nonce, 1);
+      if (u0) {// ignore vertex 0 so it can be used as nil for cuckoo[]
+        u32 nu = path(cuckoo, u0, us), nv = path(cuckoo, v0, vs);
+        if (us[nu] == vs[nv]) {
+          u32 min = nu < nv ? nu : nv;
+          for (nu -= min, nv -= min; us[nu] != vs[nv]; nu++, nv++) ;
+          u32 len = nu + nv + 1;
+          // printf("%4d-cycle found at %d:%d%%\n", len, tp->id, (u32)(nonce*100LL/HALFSIZE));
+          if (len == PROOFSIZE && ctx->nsols < ctx->maxsols)
+            ctx->solution(us, nu, vs, nv);
+        } else if (nu < nv) {
+          while (nu--)
+            cuckoo.set(us[nu+1], us[nu]);
+          cuckoo.set(u0, v0);
+        } else {
+          while (nv--)
+            cuckoo.set(vs[nv+1], vs[nv]);
+          cuckoo.set(v0, u0);
+        }
+      }
+      if (ffs & 64) break; // can't shift by 64
+    }
+  }
+  pthread_exit(NULL);
+  return 0;
+}
+
+}  // namespace cuckoo_cycle
+
+}  // namespace powa
+
+#endif  // BITCOIN_POW_CUCKOO_CYCLE_CUCKOO_MINER_H

--- a/src/pow/cuckoo_cycle/osx_barrier.h
+++ b/src/pow/cuckoo_cycle/osx_barrier.h
@@ -1,0 +1,83 @@
+#ifndef BITCOIN_POW_CUCKOO_CYCLE_OSX_BARRIER_H
+#define BITCOIN_POW_CUCKOO_CYCLE_OSX_BARRIER_H
+
+#ifdef __APPLE__
+
+#ifndef PTHREAD_BARRIER_H_
+#define PTHREAD_BARRIER_H_
+
+#include <pthread.h>
+#include <errno.h>
+
+namespace powa {
+
+namespace cuckoo_cycle {
+
+typedef int pthread_barrierattr_t;
+#define PTHREAD_BARRIER_SERIAL_THREAD 1
+
+typedef struct
+{
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    int count;
+    int tripCount;
+} pthread_barrier_t;
+
+
+int pthread_barrier_init(pthread_barrier_t *barrier, const pthread_barrierattr_t *attr, unsigned int count)
+{
+    if(count == 0)
+    {
+        errno = EINVAL;
+        return -1;
+    }
+    if(pthread_mutex_init(&barrier->mutex, 0) < 0)
+    {
+        return -1;
+    }
+    if(pthread_cond_init(&barrier->cond, 0) < 0)
+    {
+        pthread_mutex_destroy(&barrier->mutex);
+        return -1;
+    }
+    barrier->tripCount = count;
+    barrier->count = 0;
+
+    return 0;
+}
+
+int pthread_barrier_destroy(pthread_barrier_t *barrier)
+{
+    pthread_cond_destroy(&barrier->cond);
+    pthread_mutex_destroy(&barrier->mutex);
+    return 0;
+}
+
+int pthread_barrier_wait(pthread_barrier_t *barrier)
+{
+    pthread_mutex_lock(&barrier->mutex);
+    ++(barrier->count);
+    if(barrier->count >= barrier->tripCount)
+    {
+        barrier->count = 0;
+        pthread_cond_broadcast(&barrier->cond);
+        pthread_mutex_unlock(&barrier->mutex);
+        return PTHREAD_BARRIER_SERIAL_THREAD;
+    }
+    else
+    {
+        pthread_cond_wait(&barrier->cond, &(barrier->mutex));
+        pthread_mutex_unlock(&barrier->mutex);
+        return 0;
+    }
+}
+
+}  // namespace cuckoo_cycle
+
+}  // namespace powa
+
+#endif  // PTHREAD_BARRIER_H_
+#endif  // __APPLE__
+
+#endif  // BITCOIN_POW_CUCKOO_CYCLE_OSX_BARRIER_H

--- a/src/pow/cuckoo_cycle/osx_barrier.h
+++ b/src/pow/cuckoo_cycle/osx_barrier.h
@@ -25,7 +25,7 @@ typedef struct
 } pthread_barrier_t;
 
 
-int pthread_barrier_init(pthread_barrier_t *barrier, const pthread_barrierattr_t *attr, unsigned int count)
+inline int pthread_barrier_init(pthread_barrier_t *barrier, const pthread_barrierattr_t *attr, unsigned int count)
 {
     if(count == 0)
     {
@@ -47,14 +47,14 @@ int pthread_barrier_init(pthread_barrier_t *barrier, const pthread_barrierattr_t
     return 0;
 }
 
-int pthread_barrier_destroy(pthread_barrier_t *barrier)
+inline int pthread_barrier_destroy(pthread_barrier_t *barrier)
 {
     pthread_cond_destroy(&barrier->cond);
     pthread_mutex_destroy(&barrier->mutex);
     return 0;
 }
 
-int pthread_barrier_wait(pthread_barrier_t *barrier)
+inline int pthread_barrier_wait(pthread_barrier_t *barrier)
 {
     pthread_mutex_lock(&barrier->mutex);
     ++(barrier->count);

--- a/src/pow/cuckoo_cycle/siphash.h
+++ b/src/pow/cuckoo_cycle/siphash.h
@@ -1,0 +1,80 @@
+#ifndef INCLUDE_SIPHASH_H
+#define INCLUDE_SIPHASH_H
+#include <stdint.h> // for types uint32_t,uint64_t
+#include <openssl/sha.h> // if openssl absent, use #include "sha256.c"
+#include <immintrin.h>
+
+namespace powa {
+
+namespace cuckoo_cycle {
+
+// length of header hashed into siphash key
+#ifndef HEADERLEN
+#define HEADERLEN 80
+#endif
+
+// save some keystrokes since i'm a lazy typer
+typedef uint32_t u32;
+typedef uint64_t u64;
+
+// siphash uses a pair of 64-bit keys,
+typedef struct {
+  u64 k0;
+  u64 k1;
+} siphash_keys;
+
+#define U8TO64_LE(p) \
+  (((u64)((p)[0])      ) | ((u64)((p)[1]) <<  8) | \
+   ((u64)((p)[2]) << 16) | ((u64)((p)[3]) << 24) | \
+   ((u64)((p)[4]) << 32) | ((u64)((p)[5]) << 40) | \
+   ((u64)((p)[6]) << 48) | ((u64)((p)[7]) << 56))
+
+#ifndef SHA256
+#define SHA256(d, n, md) do { \
+    SHA256_CTX c; \
+    SHA256_Init(&c); \
+    SHA256_Update(&c, d, n); \
+    SHA256_Final(md, &c); \
+  } while (0)
+#endif
+
+// derive siphash key from fixed length header
+void setheader(siphash_keys *keys, const char *header) {
+  unsigned char hdrkey[32];
+  SHA256((unsigned char *)header, HEADERLEN, hdrkey);
+  keys->k0 = U8TO64_LE(hdrkey);
+  keys->k1 = U8TO64_LE(hdrkey+8);
+}
+
+#define ROTL(x,b) (u64)( ((x) << (b)) | ( (x) >> (64 - (b))) )
+#define SIPROUND \
+  do { \
+    v0 += v1; v2 += v3; v1 = ROTL(v1,13); \
+    v3 = ROTL(v3,16); v1 ^= v0; v3 ^= v2; \
+    v0 = ROTL(v0,32); v2 += v1; v0 += v3; \
+    v1 = ROTL(v1,17);   v3 = ROTL(v3,21); \
+    v1 ^= v2; v3 ^= v0; v2 = ROTL(v2,32); \
+  } while(0)
+
+// SipHash-2-4 specialized to precomputed key and 8 byte nonces
+u64 siphash24(const siphash_keys *keys, const u64 nonce) {
+  u64 v0 = keys->k0 ^ 0x736f6d6570736575ULL, v1 = keys->k1 ^ 0x646f72616e646f6dULL,
+      v2 = keys->k0 ^ 0x6c7967656e657261ULL, v3 = keys->k1 ^ 0x7465646279746573ULL ^ nonce;
+  SIPROUND; SIPROUND;
+  v0 ^= nonce;
+  v2 ^= 0xff;
+  SIPROUND; SIPROUND; SIPROUND; SIPROUND;
+  return (v0 ^ v1) ^ (v2  ^ v3);
+}
+
+#define NSIPHASH 1
+
+inline void siphash24xN(const siphash_keys *keys, const u64 *indices, u64 * hashes) {
+  *hashes = siphash24(keys, *indices);
+}
+
+}  // namespace cuckoo_cycle
+
+}  // namespace powa
+
+#endif // ifdef INCLUDE_SIPHASH_H

--- a/src/pow/pow.cpp
+++ b/src/pow/pow.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "pow/pow.h"
+#include "pow/cuckoo_cycle/cuckoo_cycle.h"
+#include "pow/sha256/sha256.h"
+
+namespace powa {
+
+bool fZeroStartingNonce = false;
+
+pow_ref pow::create(const uint32_t powid, challenge_ref c_in, callback_ref cb_in) {
+    switch (powid) {
+    case POWID_CUCKOO_CYCLE: return pow_ref(new cuckoo_cycle::cuckoo_cycle(cuckoo_cycle::cc_challenge_ref(new cuckoo_cycle::cc_challenge(*c_in)), cb_in));
+    case POWID_SHA256:       return pow_ref(new sha256(challenge_ref(new sha256challenge(*c_in)), cb_in));
+    default:
+        fprintf(stderr, "error: unknown powid:%u\n", powid);
+        return nullptr;
+    }
+}
+
+}  // namespace powa

--- a/src/pow/pow.h
+++ b/src/pow/pow.h
@@ -1,0 +1,281 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_POW_POW_H
+#define BITCOIN_POW_POW_H
+
+#include <vector>
+#include <stdint.h>
+
+#include "random.h"
+#include "serialize.h"
+#include "tinyformat.h"
+
+namespace powa {
+
+extern bool fZeroStartingNonce; ///< used for debugging to get deterministic challenges
+
+class challenge;
+class solution;
+class callback;
+class pow;
+
+typedef std::shared_ptr<challenge> challenge_ref;
+typedef std::shared_ptr<solution> solution_ref;
+typedef std::shared_ptr<callback> callback_ref;
+typedef std::shared_ptr<pow> pow_ref;
+
+enum solver_state {
+    state_ready    = 1,  //!< ready to run
+    state_running  = 2,  //!< currently running
+    state_paused   = 3,  //!< ran out of ticks, and waiting to resume
+    state_aborted  = 4,  //!< run was aborted
+    state_stopped  = 5,  //!< no longer running
+    state_term     = 6,  //!< asked to terminate
+};
+
+static const uint32_t POWID_SHA256       = 1;
+static const uint32_t POWID_CUCKOO_CYCLE = 2;
+
+class container {
+public:
+    std::vector<uint8_t> params;
+    container() {}
+    container(const std::vector<uint8_t>& params_in) : params(params_in) {}
+    container(const container& other) { params = other.params; }
+    void set_params(const uint8_t* arr, const uint32_t size) { params = std::vector<uint8_t>(arr, arr + size); }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITE(params);
+    }
+
+    virtual bool operator==(const container& other) const {
+        return params == other.params;
+    }
+};
+
+class challenge : public container {
+public:
+    container config;
+    using container::container;
+    challenge() : container() {}
+    challenge(const challenge& other) : container(other) { config = other.config; }
+    void randomize(const uint32_t bytes, const uint32_t offset = 0) {
+        if (params.size() < bytes) params.resize(bytes);
+        GetRandBytes(&params.begin()[offset], bytes);
+    }
+    /**
+     * Generate a random challenge of this POW type.
+     * @param  size Number of random bytes to generate.
+     * @return      A challenge whose params consists of size random bytes.
+     */
+    static challenge* random_challenge(const uint32_t size) {
+        challenge* c = new challenge();
+        c->randomize(size);
+        return c;
+    }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITE(config);
+        READWRITE(params);
+    }
+};
+
+class solution : public container {
+public:
+    using container::container;
+    solution() : container() {}
+    template<typename T> solution(T t) {
+        params.resize(sizeof(T));
+        memcpy(&params[0], &t, sizeof(T));
+    }
+};
+
+class pow;
+
+class callback {
+public:
+    virtual ~callback() {}
+    /**
+     * Called whenever a solution is found to a given challenge. This method
+     * should return true if the solution satisfies external requirements or
+     * false if the solver should continue finding solutions.
+     * @param  p The proof of work
+     * @param  c The challenge
+     * @param  s The solution
+     * @return   Whether the solver should continue looking.
+     */
+    virtual bool found_solution(const pow& p, challenge_ref c, solution_ref s) {
+        assert(!"not implemented found_solution callback");
+    }
+};
+
+class callback_proxy : public callback {
+public:
+    callback* actual;
+    callback_proxy(callback* actual_in) : actual(actual_in) {}
+    bool found_solution(const pow& p, challenge_ref c, solution_ref s) override {
+        return actual->found_solution(p, c, s);
+    }
+};
+
+class pow {
+public:
+    uint32_t powid;
+    challenge_ref c;
+    callback_ref cb;
+    solver_state state;
+    int32_t ticks_left;
+
+    static pow_ref create(const uint32_t powid, challenge_ref c_in, callback_ref cb_in = nullptr);
+
+    pow(uint32_t powid_in, challenge_ref c_in, callback_ref cb_in = nullptr) : powid(powid_in), c(c_in), cb(cb_in), state(state_ready) {}
+
+    /**
+     * Determine if s is a valid solution to c.
+     * @param  s A solution to this POW
+     * @return   Whether the solution solves the challenge.
+     */
+    virtual bool is_valid(solution& s) const = 0;
+
+    /**
+     * Set the given vector to the output given the solution s.
+     * @param s      The solution on which output should be based.
+     * @param output The output produced by this POW.
+     */
+    virtual void set_output(solution& s, std::vector<uint8_t>& output) = 0;
+
+    /**
+     * Attempt to solve c in the given number of threads over the given number
+     * of ticks. Whenever a solution is found, cb.found_solution is called with
+     * the given solution.
+     * @param threads    The number of threads to spin up to solve.
+     * @param background If true, the solver will create a new thread and work from there, returning control to the caller immediately.
+     * @param ticks      Number of ticks (cycles) to attempt before temporarily pausing. If -1, unlimited.
+     */
+    virtual void solve(uint32_t threads = 0, bool background = false, int32_t ticks = -1) = 0;
+
+    /**
+     * Stop solving.
+     */
+    virtual void abort() {
+        if (state == state_running) state = state_term;
+    }
+
+    virtual int64_t expected_iteration_cycles() const = 0;
+    virtual int64_t expected_invprob() const = 0;
+
+    bool operator==(const pow& other) const {
+        return powid == other.powid &&
+            *c == *other.c;
+    }
+
+    virtual std::string to_string() const {
+        return strprintf("POW<id=%u; ptr=%p>", powid, this);
+    }
+};
+
+class powchain : public pow, public callback {
+public:
+    std::vector<pow_ref> pows;
+
+    powchain(challenge_ref c_in = challenge_ref(new challenge()), callback_ref cb_in = nullptr) : pow(0, c_in, cb_in) {}
+
+    void add_pow(pow_ref p) {
+        pows.push_back(p);
+    }
+
+    bool found_solution(const pow& p, challenge_ref c, solution_ref s) override {
+        if (p == *pows.back()) {
+            if (!is_valid(*s)) return false;
+            return cb->found_solution(*this, c, s);
+        }
+        assert(p == *pows.front());
+        return cb->found_solution(p, c, s);
+    }
+
+    bool is_valid(solution& s) const override {
+        solution z = s;
+        std::vector<uint8_t> output;
+        for (auto it = pows.rbegin(); it != pows.rend(); ++it) {
+            pow* p = it->get();
+            if (!p->is_valid(z)) return false;
+            p->set_output(z, output);
+            z = solution(output);
+        }
+        return true;
+    }
+
+    void set_output(solution& s, std::vector<uint8_t>& output) override {
+        pows.back()->set_output(s, output);
+    }
+
+    void solve(uint32_t threads = 0, bool background = false, int32_t ticks = -1) override {
+        pows.back()->cb = callback_ref(new callback_proxy(this));
+        pows.back()->solve(threads, false, ticks);
+        state = pows.back()->state; // TODO: deal with background case (right now using false for background always)
+    }
+
+    int64_t expected_iteration_cycles() const override {
+        int64_t cycles = 0;
+        for (pow_ref p : pows) {
+            cycles += p->expected_iteration_cycles();
+        }
+        return cycles;
+    }
+
+    int64_t expected_invprob() const override {
+        int64_t invprob = 1;
+        for (pow_ref p : pows) {
+            invprob *= p->expected_invprob();
+        }
+        return invprob;
+    }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        if (ser_action.ForRead()) {
+            uint8_t pows_size;
+            READWRITE(pows_size);
+            pows.resize(pows_size);
+            for (uint32_t i = 0; i < pows_size; i++) {
+                uint32_t powid;
+                challenge_ref c(new challenge());
+                READWRITE(powid);
+                READWRITE(*c);
+                pow_ref p = pow::create(powid, c);
+                pows[i] = p;
+            }
+            return;
+        }
+
+        // Writing to stream
+        uint8_t pows_size = pows.size();
+        READWRITE(pows_size);
+        for (pow_ref p : pows) {
+            READWRITE(p->powid);
+            READWRITE(*p->c);
+        }
+    }
+
+    virtual std::string to_string() const override {
+        std::string s = strprintf("POW-chain<%p>[", this);
+        for (pow_ref p : pows) {
+            s += "\n\t" + p->to_string();
+        }
+        return s + "\n]";
+    }
+};
+
+}  // namespace powa
+
+#endif  // BITCOIN_POW_POW_H

--- a/src/pow/sha256/sha256.h
+++ b/src/pow/sha256/sha256.h
@@ -1,0 +1,163 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_POW_SHA256_H
+#define BITCOIN_POW_SHA256_H
+
+#include <algorithm>
+
+#include "crypto/sha256.h"
+#include "arith_uint256.h"
+#include "uint256.h"
+#include "pow/pow.h"
+
+namespace powa {
+
+class sha256;
+typedef std::shared_ptr<sha256> sha256_ref;
+
+class sha256challenge : public challenge {
+public:
+    using challenge::challenge;
+    uint32_t compact_target;
+    uint8_t nonce_size;
+    uint32_t nonce_offset;
+    sha256challenge(const challenge& other) : challenge(other) {
+        assert(config.params.size() == 9);
+        uint8_t* configb = &config.params[0];
+        compact_target = *(uint32_t*)configb;
+        configb += 4;
+        nonce_size = configb[0];
+        configb++;
+        nonce_offset = *(uint32_t*)configb;
+    }
+    sha256challenge(const uint32_t compact_target_in, const uint8_t nonce_size_in, const uint32_t nonce_offset_in, const uint32_t size) {
+        compact_target = compact_target_in;
+        nonce_size = nonce_size_in;
+        nonce_offset = nonce_offset_in;
+        uint32_t realsize = std::max(nonce_size_in + nonce_offset_in, size);
+        params.resize(realsize);
+        config.params.resize(9);
+        uint8_t* configb = &config.params[0];
+        *(uint32_t*)configb = compact_target;
+        configb += 4;
+        configb[0] = nonce_size;
+        configb++;
+        *(uint32_t*)configb = nonce_offset;
+    }
+    static challenge_ref random_challenge(const uint32_t compact_target_in, const uint8_t nonce_size_in, const uint32_t nonce_offset_in, const uint32_t size) {
+        sha256challenge* c = new sha256challenge(compact_target_in, nonce_size_in, nonce_offset_in, size);
+        c->randomize(c->params.size());
+        return challenge_ref(c);
+    }
+};
+
+class sha256 : public pow {
+public:
+    uint64_t next_nonce;
+    sha256challenge* sc;
+    sha256(challenge_ref c_in, callback_ref cb_in = nullptr) : pow(POWID_SHA256, c_in, cb_in), next_nonce(0), sc((sha256challenge*)c_in.get()) {}
+
+    uint256 get_hash(solution& s) const {
+        // two modes: if nonce_size is 0 we simply append, otherwise we expect
+        // the solution to be the size of the nonce only
+        uint32_t size;
+        uint8_t* data;
+        if (sc->nonce_size == 0) {
+            // append
+            size = sc->params.size() + s.params.size();
+            data = new uint8_t[size];
+            memcpy(data, &sc->params[0], sc->params.size());
+            memcpy(&data[sc->params.size()], &s.params[0], s.params.size());
+        } else {
+            // insert nonce only, retaining remaining challenge params
+            if (s.params.size() != sc->nonce_size) return uint256();
+            size = std::max(uint32_t(sc->nonce_offset + sc->nonce_size), uint32_t(sc->params.size()));
+            data = new uint8_t[size];
+            memcpy(data, &sc->params[0], sc->params.size());
+            memcpy(&data[sc->nonce_offset], &s.params[0], s.params.size());
+        }
+        uint256 hash;
+        CSHA256().Write(data, size).Finalize(hash.begin());
+        delete [] data;
+        return hash;
+    }
+
+    bool is_valid(solution& s) const override {
+        uint256 hash = get_hash(s);
+        arith_uint256 target;
+        target.SetCompact(sc->compact_target);
+        printf("sha256: is_valid():\n\t%s\n>\t%s\n", target.ToString().c_str(), hash.ToString().c_str());
+        return target > UintToArith256(hash);
+    }
+
+    void set_output(solution& s, std::vector<uint8_t>& output) override {
+        // the output for a sha256 POW is the full hash
+        output.resize(32);
+        memcpy(&output[0], get_hash(s).begin(), 32);
+    }
+
+    template<typename T>
+    void solve_t(T startnonce) {
+        CSHA256 sha;
+        uint256 hash;
+        arith_uint256 target;
+
+        uint32_t size = std::max(uint32_t(sc->nonce_offset + sc->nonce_size), uint32_t(sc->params.size()));
+        uint8_t* data = new uint8_t[size];
+        memcpy(data, &sc->params[0], sc->params.size());
+        T& refnonce = *(T*)&data[sc->nonce_offset];
+        target.SetCompact(sc->compact_target);
+        bool satisfied = false;
+        for (refnonce = startnonce; state == state_running && !satisfied && refnonce + 1 != startnonce; refnonce++) {
+            sha.Write(data, size);
+            sha.Finalize(hash.begin());
+            sha.Reset();
+            if (UintToArith256(hash) < target) {
+                solution_ref s(new solution(refnonce));
+                satisfied = cb->found_solution(*this, c, s);
+            }
+            ticks_left -= ticks_left > -1;
+            if (ticks_left == 0) break; // ran out of ticks
+        }
+        next_nonce = refnonce;
+        delete [] data;
+        state = state == state_term ? state_aborted : state_stopped;
+    }
+
+    void solve(uint32_t threads = 0, bool background = false, int32_t ticks = -1) override {
+        assert(state == state_ready || state == state_paused);
+        if (background || threads > 1) printf("warning: sha256 solver does not spawn threads\n");
+        if (state == state_ready && sc->nonce_size > 0 && !fZeroStartingNonce) {
+            // randomize nonce
+            GetRandBytes((unsigned char*)&next_nonce, sizeof(next_nonce));
+        }
+        state = state_running;
+        ticks_left = ticks;
+        solution_ref s(new solution());
+        switch (sc->nonce_size) {
+        case 0: if (is_valid(*s)) { cb->found_solution(*this, c, s); } return;
+        case 4: solve_t((uint32_t)next_nonce); return;
+        case 8: solve_t(next_nonce); return;
+        default: return; // we don't support this nonce size
+        }
+    }
+
+    int64_t expected_iteration_cycles() const override { return 11000; }
+
+    int64_t expected_invprob() const override {
+        arith_uint256 u;
+        u.SetCompact(sc->compact_target);
+        return 1.0 / u.GetProbabilityEstimate();
+    }
+
+    virtual std::string to_string() const override {
+        assert(sc == c.get());
+        return strprintf("SHA256<%p; target = %x; params# = %lu>", this, sc->compact_target, sc->params.size());
+    }
+};
+
+}  // namespace powa
+
+#endif  // BITCOIN_POW_SHA256_H

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -39,6 +39,8 @@ const char *SENDCMPCT="sendcmpct";
 const char *CMPCTBLOCK="cmpctblock";
 const char *GETBLOCKTXN="getblocktxn";
 const char *BLOCKTXN="blocktxn";
+const char *CHALLENGE="challenge";
+const char *SOLUTION="solution";
 };
 
 /** All known message types. Keep this in the same order as the list of
@@ -71,6 +73,8 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::CMPCTBLOCK,
     NetMsgType::GETBLOCKTXN,
     NetMsgType::BLOCKTXN,
+    NetMsgType::CHALLENGE,
+    NetMsgType::SOLUTION,
 };
 const static std::vector<std::string> allNetMessageTypesVec(allNetMessageTypes, allNetMessageTypes+ARRAYLEN(allNetMessageTypes));
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -240,6 +240,20 @@ extern const char *GETBLOCKTXN;
  * @since protocol version 70014 as described by BIP 152
  */
 extern const char *BLOCKTXN;
+/**
+ * Contains a proof of work challenge for elevated privileges.
+ * The challenge is composed of four parts -- a POW specification,
+ * a purpose specifier, an expiration date, and a signature.
+ * If the challenged peer solves the challenge, they are
+ * given the specified reward if it is still available.
+ */
+extern const char *CHALLENGE;
+/**
+ * Contains a solution to a proof of work challenge for elevated
+ * privileges. The solution contains a challenge in its entirety, and solution
+ * to the challenge.
+ */
+extern const char *SOLUTION;
 };
 
 /* Get a vector of all valid message types (see above) */
@@ -267,6 +281,9 @@ enum ServiceFlags : uint64_t {
     // NODE_XTHIN means the node supports Xtreme Thinblocks
     // If this is turned off then the node will not service nor make xthin requests
     NODE_XTHIN = (1 << 4),
+    // NODE_DOSPROT means the node is able to provide and solve challenges intended
+    // to alleviate DoS pressure on the network
+    NODE_DOSPROT = (1 << 5),
 
     // Bits 24-31 are reserved for temporary experiments. Just pick a bit that
     // isn't getting used, or one not being used much, and notify the

--- a/src/qt/bitcoinstrings.cpp
+++ b/src/qt/bitcoinstrings.cpp
@@ -310,6 +310,7 @@ QT_TRANSLATE_NOOP("bitcoin-core", "Location of the auth cookie (default: data di
 QT_TRANSLATE_NOOP("bitcoin-core", "Maintain at most <n> connections to peers (default: %u)"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Make the wallet broadcast transactions"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Maximum per-connection receive buffer, <n>*1000 bytes (default: %u)"),
+QT_TRANSLATE_NOOP("bitcoin-core", "Reserve <n> slots for proof of work challenged peers (default: %u)"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Maximum per-connection send buffer, <n>*1000 bytes (default: %u)"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Need to specify a port with -whitebind: '%s'"),
 QT_TRANSLATE_NOOP("bitcoin-core", "Node relay options:"),

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -930,6 +930,9 @@ QString formatServicesStr(quint64 mask)
             case NODE_XTHIN:
                 strList.append("XTHIN");
                 break;
+            case NODE_DOSPROT:
+                strList.append("DOSPROT");
+                break;
             default:
                 strList.append(QString("%1[%2]").arg("UNKNOWN").arg(check));
             }

--- a/src/test/arith_uint256_tests.cpp
+++ b/src/test/arith_uint256_tests.cpp
@@ -537,6 +537,17 @@ BOOST_AUTO_TEST_CASE(bignum_SetCompact)
     BOOST_CHECK_EQUAL(fOverflow, true);
 }
 
+BOOST_AUTO_TEST_CASE(probabilityTarget)
+{
+    arith_uint256 t;
+    for (uint32_t target_attempts = 1; target_attempts < 256; target_attempts++) {
+        double pt = 1.0/target_attempts;
+        t.SetProbabilityTarget(pt);
+        double got = t.GetProbabilityEstimate();
+        BOOST_CHECK(std::abs(got - pt) < 0.0000001);
+    }
+}
+
 
 BOOST_AUTO_TEST_CASE( getmaxcoverage ) // some more tests just to get 100% coverage
 {

--- a/src/test/pow_chain_tests.cpp
+++ b/src/test/pow_chain_tests.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "test/test_bitcoin.h"
+#include "pow/sha256/sha256.h"
+#include "pow/cuckoo_cycle/cuckoo_cycle.h"
+
+#include <boost/test/unit_test.hpp>
+
+class collector_chain : public powa::callback {
+public:
+	bool finished;
+	powa::solution_ref sol;
+	collector_chain(powa::solution_ref sol_in) : finished(false), sol(sol_in) {}
+	bool found_solution(const powa::pow& p, powa::challenge_ref c, powa::solution_ref s) override {
+		printf("found solution\n");
+		sol = s;
+		finished = true;
+		return true;
+	}
+};
+
+BOOST_FIXTURE_TEST_SUITE(pow_chain_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(pow_chain_tests)
+{
+	powa::fZeroStartingNonce = true;
+	// zero header case
+	{
+		powa::challenge_ref chlg(new powa::sha256challenge(0x207fffff, 0, 0, 0));
+		powa::cuckoo_cycle::cc_challenge_ref chlg2(new powa::cuckoo_cycle::cc_challenge());
+		chlg2->params.resize(80);
+		memset(&chlg2->params[0], 0, 80);
+		powa::solution_ref sol(new powa::solution());
+		sol->params.resize(4 * 43);
+		memset(&sol->params[0], 0, 4 * 43);
+		collector_chain* coll = new collector_chain(sol);
+		powa::callback_ref collref(coll);
+		powa::pow_ref alg(new powa::sha256(chlg));
+		powa::pow_ref alg2(new powa::cuckoo_cycle::cuckoo_cycle(chlg2));
+		powa::powchain chain;
+		chain.add_pow(alg);
+		chain.add_pow(alg2);
+		chain.cb = collref;
+		// the zero bit solution should not solve the zero header challenge
+		BOOST_CHECK(!chain.is_valid(*coll->sol));
+		// now solve the challenge; it should be solved within 5 attempts
+		chain.solve(0, false, 200);
+		// we should have solved the challenge
+		BOOST_CHECK(coll->finished == true);
+		// the solution should now solve the challenge
+		BOOST_CHECK(chain.is_valid(*coll->sol));
+		printf("done zero header case\n");
+	}
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/pow_cuckoo_cycle_tests.cpp
+++ b/src/test/pow_cuckoo_cycle_tests.cpp
@@ -1,0 +1,71 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "test/test_bitcoin.h"
+#include "pow/cuckoo_cycle/cuckoo_cycle.h"
+
+#include <boost/test/unit_test.hpp>
+
+class cc_collector : public powa::callback {
+public:
+	bool finished;
+	powa::solution_ref sol;
+	cc_collector(powa::solution_ref _sol) : finished(false), sol(_sol) {}
+	bool found_solution(const powa::pow& p, powa::challenge_ref c, powa::solution_ref s) override {
+		sol = s;
+		finished = true;
+		return true;
+	}
+};
+
+BOOST_FIXTURE_TEST_SUITE(pow_cuckoo_cycle_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(pow_cuckoo_cycle_tests)
+{
+	powa::fZeroStartingNonce = true;
+	// zero header case
+	{
+		uint32_t nonces[42];
+		memset(nonces, 0, sizeof(nonces));
+		powa::cuckoo_cycle::cc_challenge_ref chlg(new powa::cuckoo_cycle::cc_challenge());
+		powa::solution_ref sol(new powa::solution());
+		sol->params.resize(4 * 43);
+		memset(&sol->params[0], 0, 4 * 43);
+		cc_collector* coll = new cc_collector(sol);
+		powa::callback_ref collref(coll);
+		powa::cuckoo_cycle::cuckoo_cycle alg(chlg, collref);
+		// the zero bit solution should not solve the zero header challenge
+		BOOST_CHECK(!alg.is_valid(*coll->sol));
+		// now solve the challenge; it should find a solution at nonce 2
+		alg.next_nonce = 2;
+		alg.solve(0, false, 1);
+		// we should have solved the challenge
+		BOOST_CHECK(coll->finished == true);
+		// the solution should now solve the challenge
+		BOOST_CHECK(alg.is_valid(*coll->sol));
+	}
+
+	// HEADERLEN byte header case
+	{
+		uint32_t nonces[42];
+		memset(nonces, 0, sizeof(nonces));
+		powa::cuckoo_cycle::cc_challenge_ref chlg = powa::cuckoo_cycle::cc_challenge::random_challenge(HEADERLEN);
+		powa::solution_ref sol(new powa::solution());
+		sol->params.resize(4 * 43);
+		memset(&sol->params[0], 0, 4 * 43);
+		cc_collector* coll = new cc_collector(sol);
+		powa::callback_ref collref(coll);
+		powa::cuckoo_cycle::cuckoo_cycle alg(chlg, collref);
+		// the zero bit solution should not solve the random header challenge
+		BOOST_CHECK(!alg.is_valid(*coll->sol));
+		// now solve the challenge; it should find a solution before nonce 5
+		alg.solve(0, false, 5);
+		// we should have solved the challenge
+		BOOST_CHECK(coll->finished == true);
+		// the solution should now solve the challenge
+		BOOST_CHECK(alg.is_valid(*coll->sol));
+	}
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/pow_sha256_tests.cpp
+++ b/src/test/pow_sha256_tests.cpp
@@ -1,0 +1,76 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "test/test_bitcoin.h"
+#include "pow/sha256/sha256.h"
+
+#include <boost/test/unit_test.hpp>
+
+int WriteHex(uint8_t* dst, const char* hex) {
+	int i = 0;
+	while (hex[i]) {
+		char l = hex[i++];
+		char r = hex[i++];
+		uint8_t v = (l >= 'a' && l <= 'f' ? 10 + l - 'a' : l - '0');
+		*(dst++) = (v << 4) | (r >= 'a' && r <= 'f' ? 10 + r - 'a' : r - '0');
+	}
+	return i;
+}
+
+class collector_sha256 : public powa::callback {
+public:
+	bool finished;
+	powa::solution_ref sol;
+	collector_sha256(powa::solution_ref sol_in) : finished(false), sol(sol_in) {}
+	bool found_solution(const powa::pow& p, powa::challenge_ref c, powa::solution_ref s) override {
+		printf("found solution\n");
+		sol = s;
+		finished = true;
+		return true;
+	}
+};
+
+BOOST_FIXTURE_TEST_SUITE(pow_sha256_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(pow_sha256_tests)
+{
+	powa::fZeroStartingNonce = true;
+	// zero header case
+	{
+		powa::challenge_ref chlg(new powa::sha256challenge(0x200fffff, 4, 0, 0));
+		collector_sha256* coll = new collector_sha256(powa::solution_ref(new powa::solution((uint32_t)0)));
+		powa::callback_ref collref(coll);
+		powa::sha256 alg(chlg, collref);
+		// the zero bit solution should not solve the zero header challenge
+		BOOST_CHECK(!alg.is_valid(*coll->sol));
+		// now solve the challenge; it should be solved within 5 attempts
+		alg.solve(0, false, 5);
+		// we should have solved the challenge
+		BOOST_CHECK(coll->finished == true);
+		// the solution should now solve the challenge
+		BOOST_CHECK(alg.is_valid(*coll->sol));
+		printf("done zero header case\n");
+	}
+
+	// HEADERLEN byte header case
+	{
+		uint8_t randomness[80];
+		WriteHex(randomness, "43fcd0d3ee002389ff95c7e2c568aa0d5206688dd05589d5d5b040fd4bf837081911b814c02405e88c49bc52dc8a77ea48d73dc42d195740db2fa90498613fdfe96da5c2e3ba8deca6c65b9635");
+		powa::challenge_ref chlg(new powa::sha256challenge(0x200fffff, 4, 76, 80));
+		collector_sha256* coll = new collector_sha256(powa::solution_ref(new powa::solution((uint32_t)0)));
+		powa::callback_ref collref(coll);
+		chlg->set_params(randomness, 80);
+		powa::sha256 alg(chlg, collref);
+		// the zero bit solution does not solve the random header challenge (it isn't random, or we wouldn't be sure about that)
+		BOOST_CHECK(!alg.is_valid(*coll->sol));
+		// now solve the challenge; it should be solved within 11 attempts
+		alg.solve(0, false, 11);
+		// we should have solved the challenge
+		BOOST_CHECK(coll->finished == true);
+		// the solution should now solve the challenge
+		BOOST_CHECK(alg.is_valid(*coll->sol));
+	}
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Code is experimental but it works. It drops settings down heavily for easy testing. Normally, you would have something like 75 free slots and 50 POW slots or something (in bitcoin default there are 125 free slots).

The code:
- adds cuckoo cycle POW support, to force the connector to use CPU resources to solve the challenge,
- adds SHA256 POW support,
- adds a new ados namespace which facilitates solving and challenging
- adds two new commands to the network peer protocol: CHALLENGE and SOLUTION
- adds a new service bit called NODE_DOSPROT (`1<<5`) which indicates the node is able to do POW for services (may be used e.g. for bloom filters as a quick hack before they are replaced).
